### PR TITLE
Update 2022-01-17-curl-utf-8.md

### DIFF
--- a/_posts/2022-01-17-curl-utf-8.md
+++ b/_posts/2022-01-17-curl-utf-8.md
@@ -17,7 +17,7 @@ curl -H "Content-Type: application/json; charset=utf-8" -d '{"op":"shareToPublis
 
 I was thinking that, OK, I have `charset=utf-8` in my `Content-Type` and that's it, `curl` should encode input data correctly, right? At least, that was what some clever people suggested on `StackOverflow`.
 
-Well, then I decided to see what is actually sent with `--trace` option and that clearly showed, that `č` characters are encoded as `e8` (HEX) which is not what I would [expect](https://unicode-table.com/en/010D/).
+Well, then I decided to see what is actually sent with `--trace` option and that clearly showed, that `č` characters are encoded as `e8` (HEX) which is not what I would [expect](https://symbl.cc/en/010D/).
 
 I subsequently checked my command line "encoding" with `locale` command and that was OK, I had `cs_CZ.UTF-8` there. It seems, that for some reason, `curl` was encoding my data as `windows-1250`, not `UTF-8`.
 


### PR DESCRIPTION
This URL https://unicode-table.com/ has changed to https://symbl.cc/